### PR TITLE
Fix ImageCropView with long images

### DIFF
--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/DocumentScannerActivity.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/DocumentScannerActivity.kt
@@ -9,10 +9,7 @@ import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
 import com.websitebeaver.documentscanner.constants.DefaultSetting
 import com.websitebeaver.documentscanner.constants.DocumentScannerExtra
-import com.websitebeaver.documentscanner.extensions.move
-import com.websitebeaver.documentscanner.extensions.onClick
-import com.websitebeaver.documentscanner.extensions.saveToFile
-import com.websitebeaver.documentscanner.extensions.screenWidth
+import com.websitebeaver.documentscanner.extensions.*
 import com.websitebeaver.documentscanner.models.Document
 import com.websitebeaver.documentscanner.models.Quad
 import com.websitebeaver.documentscanner.ui.ImageCropView
@@ -95,7 +92,7 @@ class DocumentScannerActivity : AppCompatActivity() {
                 // user is allowed to move corners to make corrections
                 try {
                     // set preview image height based off of photo dimensions
-                    imageView.setImagePreviewHeight(photo, screenWidth)
+                    imageView.setImagePreviewHeight(photo, screenWidth, screenHeight)
 
                     // display original photo, so user can adjust detected corners
                     imageView.setImageBitmap(photo)

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/extensions/AppCompatActivity.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/extensions/AppCompatActivity.kt
@@ -24,3 +24,8 @@ val AppCompatActivity.screenBounds: Rect get() {
  * @property screenWidth the screen width
  */
 val AppCompatActivity.screenWidth: Int get() = screenBounds.width()
+
+/**
+ * @property screenHeight the screen height
+ */
+val AppCompatActivity.screenHeight: Int get() = screenBounds.height()

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/ui/ImageCropView.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/ui/ImageCropView.kt
@@ -12,6 +12,7 @@ import com.websitebeaver.documentscanner.enums.QuadCorner
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Color
+import com.websitebeaver.documentscanner.R
 import com.websitebeaver.documentscanner.extensions.drawQuad
 import com.websitebeaver.documentscanner.models.Quad
 
@@ -83,13 +84,18 @@ class ImageCropView(context: Context, attrs: AttributeSet) : AppCompatImageView(
      * @param photo the original photo with a rectangular document
      * @param screenWidth the device width
      */
-    fun setImagePreviewHeight(photo: Bitmap, screenWidth: Int) {
+    fun setImagePreviewHeight(photo: Bitmap, screenWidth: Int, screenHeight: Int) {
         // image width to height aspect ratio
         val imageRatio = photo.width.toFloat() / photo.height.toFloat()
+        val buttonsViewMinHeight = context.resources.getDimension(R.dimen.image_crop_view_bottom_bar_min_height).toInt()
 
         imagePreviewHeight = if (photo.height > photo.width) {
             // if user takes the photo in portrait
-            (screenWidth.toFloat() / imageRatio).toInt()
+            Integer.min(
+                (screenWidth.toFloat() / imageRatio).toInt(),
+                screenHeight - buttonsViewMinHeight
+            )
+
         } else {
             // if user takes the photo in landscape
             (screenWidth.toFloat() * imageRatio).toInt()

--- a/documentscanner/src/main/res/values/dimens.xml
+++ b/documentscanner/src/main/res/values/dimens.xml
@@ -8,6 +8,7 @@
     <dimen name="grown_button_zoom">1.07</dimen>
     <dimen name="image_crop_view_initial_height">0dp</dimen>
     <dimen name="image_crop_view_vertical_padding">15.4dp</dimen>
+    <dimen name="image_crop_view_bottom_bar_min_height">200dp</dimen>
     <dimen name="large_button_diameter">75dp</dimen>
     <dimen name="large_button_ring_thickness">2.91dp</dimen>
     <dimen name="large_button_outer_ring_offset">8dp</dimen>


### PR DESCRIPTION
Fix the issue [https://github.com/WebsiteBeaver/react-native-document-scanner-plugin/issues/4](https://github.com/WebsiteBeaver/react-native-document-scanner-plugin/issues/4) that happen when images have a short width and long height. In that case the bottom bar with buttons on the ImageCropView is outside the screen.

![Screenshot_20221021-225139](https://user-images.githubusercontent.com/43968171/197286969-9e4ac1d6-b2ce-4c1c-b47b-22fbdceca240.jpg)


