### PR TITLE
Add an option to use "quickCapture" to circumvent the "Retry"/"Ok" screen

### DIFF
--- a/documentscanner-demo/src/main/java/com/websitebeaver/documentscanner/demo/MainActivity.kt
+++ b/documentscanner-demo/src/main/java/com/websitebeaver/documentscanner/demo/MainActivity.kt
@@ -23,7 +23,8 @@ class MainActivity : AppCompatActivity() {
      */
     private val documentScanner = DocumentScanner(
         this,
-        { croppedImageResults ->
+        useQuickCapture = true,
+        successHandler = { croppedImageResults ->
             // display the first cropped image
             croppedImageView.setImageBitmap(
                 ImageUtil().readBitmapFromFileUriString(
@@ -32,11 +33,11 @@ class MainActivity : AppCompatActivity() {
                 )
             )
         },
-        {
+        errorHandler = {
             // an error happened
                 errorMessage -> Log.v("documentscannerlogs", errorMessage)
         },
-        {
+        cancelHandler = {
             // user canceled document scan
             Log.v("documentscannerlogs", "User canceled document scan")
         }

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/DocumentScanner.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/DocumentScanner.kt
@@ -33,6 +33,7 @@ class DocumentScanner(
     private val cancelHandler: (() -> Unit)? = null,
     private var responseType: String? = null,
     private var letUserAdjustCrop: Boolean? = null,
+    private var useQuickCapture: Boolean? = null,
     private var maxNumDocuments: Int? = null,
     private var croppedImageQuality: Int? = null
 ) {
@@ -53,6 +54,10 @@ class DocumentScanner(
         documentScanIntent.putExtra(
             DocumentScannerExtra.EXTRA_LET_USER_ADJUST_CROP,
             letUserAdjustCrop
+        )
+        documentScanIntent.putExtra(
+            DocumentScannerExtra.EXTRA_USE_QUICK_CAPTURE,
+            useQuickCapture
         )
         documentScanIntent.putExtra(
             DocumentScannerExtra.EXTRA_MAX_NUM_DOCUMENTS,

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/DocumentScannerActivity.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/DocumentScannerActivity.kt
@@ -44,6 +44,12 @@ class DocumentScannerActivity : AppCompatActivity() {
     private var letUserAdjustCrop = DefaultSetting.LET_USER_ADJUST_CROP
 
     /**
+     * @property useQuickCapture whether to use "quickCapture" to bypass default "Retry"/"Ok"
+     * behaviour
+     */
+    private var useQuickCapture = DefaultSetting.USE_QUICK_CAPTURE
+
+    /**
      * @property croppedImageQuality the 0 - 100 quality of the cropped image
      */
     private var croppedImageQuality = DefaultSetting.CROPPED_IMAGE_QUALITY
@@ -210,6 +216,15 @@ class DocumentScannerActivity : AppCompatActivity() {
                 }
             }
 
+            intent.extras?.get(DocumentScannerExtra.EXTRA_USE_QUICK_CAPTURE)?.let {
+                if (!arrayOf("true", "false").contains(it.toString())) {
+                    throw Exception(
+                        "${DocumentScannerExtra.EXTRA_USE_QUICK_CAPTURE} must true or false"
+                    )
+                }
+                useQuickCapture = it as Boolean
+            }
+
             // validate croppedImageQuality option, and update value if user sets it
             intent.extras?.get(DocumentScannerExtra.EXTRA_CROPPED_IMAGE_QUALITY)?.let {
                 if (it !is Int || it < 0 || it > 100) {
@@ -287,7 +302,7 @@ class DocumentScannerActivity : AppCompatActivity() {
      */
     private fun openCamera() {
         document = null
-        cameraUtil.openCamera(documents.size)
+        cameraUtil.openCamera(documents.size, useQuickCapture)
     }
 
     /**

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/constants/DefaultSetting.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/constants/DefaultSetting.kt
@@ -7,6 +7,7 @@ class DefaultSetting {
     companion object {
         const val CROPPED_IMAGE_QUALITY = 100
         const val LET_USER_ADJUST_CROP = true
+        const val USE_QUICK_CAPTURE = false
         const val MAX_NUM_DOCUMENTS = 24
         const val RESPONSE_TYPE = ResponseType.IMAGE_FILE_PATH
     }

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/constants/DocumentScannerExtra.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/constants/DocumentScannerExtra.kt
@@ -7,6 +7,7 @@ class DocumentScannerExtra {
     companion object {
         const val EXTRA_CROPPED_IMAGE_QUALITY = "croppedImageQuality"
         const val EXTRA_LET_USER_ADJUST_CROP = "letUserAdjustCrop"
+        const val EXTRA_USE_QUICK_CAPTURE = "useQuickCapture"
         const val EXTRA_MAX_NUM_DOCUMENTS = "maxNumDocuments"
     }
 }

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/utils/CameraUtil.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/utils/CameraUtil.kt
@@ -54,9 +54,12 @@ class CameraUtil(
      * @param pageNumber the current document page number
      */
     @Throws(IOException::class)
-    fun openCamera(pageNumber: Int) {
+    fun openCamera(pageNumber: Int, useQuickCapture: Boolean = false) {
         // create intent to launch camera
         val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        if (useQuickCapture) {
+            takePictureIntent.putExtra("android.intent.extra.quickCapture", true)
+        }
 
         // create new file for photo
         val photoFile: File = FileUtil().createImageFile(activity, pageNumber)


### PR DESCRIPTION
This PR adds a configuration option "useQuickCapture" to use the "android.intent.extra.quickCapture" option when creating the ACTION_IMAGE_CAPTURE intent.

This circumvents the additional "Retry"/"Ok" screen that is, in my opinion, redundant because the crop screen already provides such options. This speeds up the overall workflow of using the document scanner.

This might need some adjustment so that either "letUserAdjustCrop" or "useQuickCapture" should be enabled.