### PR TITLE
Decrease image quality when get OutOfMemoryError exception

### DIFF
--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/utils/ImageUtil.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/utils/ImageUtil.kt
@@ -51,7 +51,14 @@ class ImageUtil {
         }
 
         // try reading image without OpenCV
-        var imageBitmap = BitmapFactory.decodeFile(filePath)
+        var imageBitmap
+        try {
+            imageBitmap = BitmapFactory.decodeFile(filePath)
+        } catch (OutOfMemoryError e) {
+            var options = new BitmapFactory.Options();
+            options.inSampleSize = 2;
+            imageBitmap = BitmapFactory.decodeFile(filePath, options);
+        }
         val rotation = when (ExifInterface(filePath).getAttributeInt(
             ExifInterface.TAG_ORIENTATION,
             ExifInterface.ORIENTATION_NORMAL

--- a/documentscanner/src/main/java/com/websitebeaver/documentscanner/utils/ImageUtil.kt
+++ b/documentscanner/src/main/java/com/websitebeaver/documentscanner/utils/ImageUtil.kt
@@ -51,11 +51,11 @@ class ImageUtil {
         }
 
         // try reading image without OpenCV
-        var imageBitmap
+        var imageBitmap: Bitmap
         try {
             imageBitmap = BitmapFactory.decodeFile(filePath)
-        } catch (OutOfMemoryError e) {
-            var options = new BitmapFactory.Options();
+        } catch (e: OutOfMemoryError) {
+            var options = BitmapFactory.Options();
             options.inSampleSize = 2;
             imageBitmap = BitmapFactory.decodeFile(filePath, options);
         }


### PR DESCRIPTION
If set to a value > 1, requests the decoder to subsample the original image, returning a smaller image to save memory. The sample size is the number of pixels in either dimension that correspond to a single pixel in the decoded bitmap. For example, inSampleSize == 4 returns an image that is 1/4 the width/height of the original.

Reference: 
https://stackoverflow.com/questions/8442316/bitmap-is-returning-null-from-bitmapfactory-decodefilefilename

Fixes: #34 (maybe)